### PR TITLE
feat: migrate local structs to `svc-storage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,8 +1668,8 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.9.0-develop.9"
-source = "git+https://github.com/Arrow-air/svc-storage?branch=develop#75e465de5585850e271cf5bb4ac18e05dfc7864f"
+version = "0.9.0-develop.10"
+source = "git+https://github.com/Arrow-air/svc-storage?tag=v0.9.0-develop.10#061a5ab76f308dd3815974adfb9359043a63b555"
 dependencies = [
  "geo-types",
  "num-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,8 +1668,8 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.1.0"
-source = "git+https://github.com/Arrow-air/svc-storage?tag=v0.2.0#db614e0422df69b4e47c1fe35de5e76a56212fb0"
+version = "0.9.0-develop.9"
+source = "git+https://github.com/Arrow-air/svc-storage?branch=develop#75e465de5585850e271cf5bb4ac18e05dfc7864f"
 dependencies = [
  "geo-types",
  "num-derive",

--- a/openapi/types.rs
+++ b/openapi/types.rs
@@ -1,7 +1,6 @@
+use crate::structs::{AssetStatus, Location};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
-
-use crate::structs::{AssetStatus, Location};
 
 /// Request to create an aircraft.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, IntoParams)]
@@ -31,6 +30,8 @@ pub struct RegisterAircraftPayload {
     pub description: Option<String>,
     pub max_payload_kg: f64,
     pub max_range_km: f64,
+    pub last_maintenance: Option<String>,
+    pub next_maintenance: Option<String>,
 }
 
 /// Request to create a vertiport.
@@ -49,9 +50,12 @@ pub struct RegisterVertiportPayload {
 /// Request to create a vertipad.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, IntoParams)]
 pub struct RegisterVertipadPayload {
+    pub name: Option<String>,
     pub vertiport_id: String,
     pub status: AssetStatus,
     pub location: Location,
+    pub enabled: bool,
+    pub occupied: bool,
 }
 
 /// Request to create an asset group.
@@ -62,4 +66,47 @@ pub struct RegisterAssetGroupPayload {
     pub owner: String,
     /// A list of UUIDs of assets.
     pub assets: Vec<String>,
+}
+
+/// Request to update an aircraft.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, IntoParams)]
+pub struct UpdateAircraftPayload {
+    pub id: String,
+    /// The UUID of the model.
+    pub vehicle_model_id: Option<String>,
+    pub last_vertiport_id: Option<Option<String>>,
+    pub serial_number: Option<String>,
+    pub registration_number: Option<String>,
+    pub description: Option<Option<String>>,
+    pub asset_group_id: Option<Option<String>>,
+    pub schedule: Option<Option<String>>,
+    pub last_maintenance: Option<Option<String>>,
+    pub next_maintenance: Option<Option<String>>,
+    pub mask: Vec<String>,
+}
+
+/// Request to update a vertiport.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, IntoParams)]
+pub struct UpdateVertiportPayload {
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub schedule: Option<Option<String>>,
+    pub mask: Vec<String>,
+}
+
+/// Request to update a vertipad.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, IntoParams)]
+pub struct UpdateVertipadPayload {
+    pub id: String,
+    pub vertiport_id: Option<String>,
+    pub name: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub enabled: Option<bool>,
+    pub occupied: Option<bool>,
+    pub schedule: Option<Option<String>>,
+    pub mask: Vec<String>,
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,7 +36,7 @@ prost-types             = "0.11"
 rand                    = { version = "0.8" }
 serde                   = "1.0"
 serde_json              = "1.0"
-svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage", branch = "develop" }
+svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage", tag = "v0.9.0-develop.10" }
 tokio                   = { version = "1.20", features = ["full"] }
 tokio-util              = "0.7"
 tonic                   = "0.8"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,7 +36,7 @@ prost-types             = "0.11"
 rand                    = { version = "0.8" }
 serde                   = "1.0"
 serde_json              = "1.0"
-svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage", tag = "v0.2.0" }
+svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage", branch = "develop" }
 tokio                   = { version = "1.20", features = ["full"] }
 tokio-util              = "0.7"
 tonic                   = "0.8"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -166,27 +166,36 @@ pub async fn rest_server(grpc_clients: GrpcClients) {
         // .merge(SwaggerUi::new("/swagger-ui/*tail").url("/api-doc/openapi.json", ApiDoc::openapi()))
         .fallback(not_found.into_service())
         // GET endpoints
-        .route("/operators/:id", routing::get(rest_api::get_operator))
         .route(
-            "/operators/:id/assets",
+            "/assets/operators/:id",
+            routing::get(rest_api::get_operator),
+        )
+        .route(
+            "/assets/operators/:id/assets",
             routing::get(rest_api::get_all_assets),
         )
         .route(
-            "/operators/:id/grouped",
+            "/assets/operators/:id/grouped",
             routing::get(rest_api::get_all_grouped_assets),
         )
         .route(
-            "/operators/:id/grouped/delegated-to",
+            "/assets/operators/:id/grouped/delegated-to",
             routing::get(rest_api::get_all_grouped_assets_delegated_to),
         )
         .route(
-            "/operators/:id/grouped/delegated-from",
+            "/assets/operators/:id/grouped/delegated-from",
             routing::get(rest_api::get_all_grouped_assets_delegated_from),
         )
-        .route("/aircraft/:id", routing::get(rest_api::get_aircraft_by_id))
-        .route("/vertipads/:id", routing::get(rest_api::get_vertipad_by_id))
         .route(
-            "/vertiports/:id",
+            "/assets/aircraft/:id",
+            routing::get(rest_api::get_aircraft_by_id),
+        )
+        .route(
+            "/assets/vertipads/:id",
+            routing::get(rest_api::get_vertipad_by_id),
+        )
+        .route(
+            "/assets/vertiports/:id",
             routing::get(rest_api::get_vertiport_by_id),
         )
         .route(
@@ -194,28 +203,52 @@ pub async fn rest_server(grpc_clients: GrpcClients) {
             routing::get(rest_api::get_asset_group_by_id),
         )
         // POST endpoints
-        .route("/aircraft", routing::post(rest_api::register_aircraft))
-        .route("/vertiports", routing::post(rest_api::register_vertiport))
-        .route("/vertipads", routing::post(rest_api::register_vertipad))
+        .route(
+            "/assets/aircraft",
+            routing::post(rest_api::register_aircraft),
+        )
+        .route(
+            "/assets/vertiports",
+            routing::post(rest_api::register_vertiport),
+        )
+        .route(
+            "/assets/vertipads",
+            routing::post(rest_api::register_vertipad),
+        )
         .route(
             "/assets/groups",
             routing::post(rest_api::register_asset_group),
         )
         // PUT endpoints
-        .route("/aircraft/:id", routing::put(rest_api::update_aircraft))
-        .route("/vertiports/:id", routing::put(rest_api::update_vertiport))
-        .route("/vertipads/:id", routing::put(rest_api::update_vertipad))
+        .route(
+            "/assets/aircraft/:id",
+            routing::put(rest_api::update_aircraft),
+        )
+        .route(
+            "/assets/vertiports/:id",
+            routing::put(rest_api::update_vertiport),
+        )
+        .route(
+            "/assets/vertipads/:id",
+            routing::put(rest_api::update_vertipad),
+        )
         .route(
             "/assets/groups/:id",
             routing::put(rest_api::update_asset_group),
         )
         // DELETE endpoints
-        .route("/aircraft/:id", routing::delete(rest_api::remove_aircraft))
         .route(
-            "/vertiports/:id",
+            "/assets/aircraft/:id",
+            routing::delete(rest_api::remove_aircraft),
+        )
+        .route(
+            "/assets/vertiports/:id",
             routing::delete(rest_api::remove_vertiport),
         )
-        .route("/vertipads/:id", routing::delete(rest_api::remove_vertipad))
+        .route(
+            "/assets/vertipads/:id",
+            routing::delete(rest_api::remove_vertipad),
+        )
         .route(
             "/assets/groups/:id",
             routing::delete(rest_api::remove_asset_group),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -220,18 +220,12 @@ pub async fn rest_server(grpc_clients: GrpcClients) {
             routing::post(rest_api::register_asset_group),
         )
         // PUT endpoints
+        .route("/assets/aircraft", routing::put(rest_api::update_aircraft))
         .route(
-            "/assets/aircraft/:id",
-            routing::put(rest_api::update_aircraft),
-        )
-        .route(
-            "/assets/vertiports/:id",
+            "/assets/vertiports",
             routing::put(rest_api::update_vertiport),
         )
-        .route(
-            "/assets/vertipads/:id",
-            routing::put(rest_api::update_vertipad),
-        )
+        .route("/assets/vertipads", routing::put(rest_api::update_vertipad))
         .route(
             "/assets/groups/:id",
             routing::put(rest_api::update_asset_group),

--- a/server/src/rest_api.rs
+++ b/server/src/rest_api.rs
@@ -38,7 +38,7 @@ fn is_uuid(s: &str) -> bool {
 /// Get info about an operator by id.
 #[utoipa::path(
     get,
-    path = "/operators/{id}",
+    path = "/assets/operators/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Operator found in database"),
@@ -75,7 +75,7 @@ pub async fn get_operator(
 //-----------------------------------------------------------
 #[utoipa::path(
     get,
-    path = "/operators/{id}/assets",
+    path = "/assets/operators/{id}/assets",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Assets found from database for operator {id}"),
@@ -115,7 +115,7 @@ pub async fn get_all_assets(
 /// Returns a list of grouped asset ids.
 #[utoipa::path(
     get,
-    path = "/operators/{id}/grouped",
+    path = "/assets/operators/{id}/grouped",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Grouped assets found from database for operator {id}"),
@@ -150,7 +150,7 @@ pub async fn get_all_grouped_assets(
 /// Get all grouped assets delegated to an operator.
 #[utoipa::path(
     get,
-    path = "/operators/{id}/grouped/delegated-to",
+    path = "/assets/operators/{id}/grouped/delegated-to",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Grouped assets delegated to operator {id} found from database"),
@@ -185,7 +185,7 @@ pub async fn get_all_grouped_assets_delegated_to(
 /// Get all grouped assets delegated from an operator.
 #[utoipa::path(
     get,
-    path = "/operators/{id}/grouped/delegated-from",
+    path = "/assets/operators/{id}/grouped/delegated-from",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Grouped assets delegated from operator {id} found from database"),
@@ -224,7 +224,7 @@ pub async fn get_all_grouped_assets_delegated_from(
 /// Get an [`Aircraft`] by its id.
 #[utoipa::path(
     get,
-    path = "/aircraft/{id}",
+    path = "/assets/aircraft/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Aircraft {id} found from database"),
@@ -261,7 +261,7 @@ pub async fn get_aircraft_by_id(
 /// Get an [`Vertipad`] by its id.
 #[utoipa::path(
     get,
-    path = "/vertipads/{id}",
+    path = "/assets/vertipads/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Vertipad {id} found from database"),
@@ -298,7 +298,7 @@ pub async fn get_vertipad_by_id(
 /// Get an [`Vertiport`] by its id.
 #[utoipa::path(
     get,
-    path = "/vertiports/{id}",
+    path = "/assets/vertiports/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Vertiport {id} found from database"),
@@ -376,7 +376,7 @@ pub async fn get_asset_group_by_id(
 /// Register an [`Aircraft`] in the database.
 #[utoipa::path(
     post,
-    path = "/aircraft",
+    path = "/assets/aircraft",
     tag = "svc-assets",
     request_body=RegisterAircraftPayload,
     responses(
@@ -437,7 +437,7 @@ pub async fn register_aircraft(
 /// Register an [`Vertiport`] in the database.
 #[utoipa::path(
     post,
-    path = "/vertiports",
+    path = "/assets/vertiports",
     tag = "svc-assets",
     request_body=RegisterVertiportPayload,
     responses(
@@ -495,7 +495,7 @@ pub async fn register_vertiport(
 /// Also inserts the vertipad into the vertiport's vertipad list.
 #[utoipa::path(
     post,
-    path = "/vertipads",
+    path = "/assets/vertipads",
     tag = "svc-assets",
     request_body=RegisterVertipadPayload,
     responses(
@@ -604,7 +604,7 @@ pub async fn register_asset_group(
 /// This will update the aircraft's information.
 #[utoipa::path(
     put,
-    path = "/aircraft/{id}",
+    path = "/assets/aircraft/{id}",
     tag = "svc-assets",
     request_body=Aircraft,
     responses(
@@ -655,7 +655,7 @@ pub async fn update_aircraft(
 /// perform batch add/remove of vertipads.
 #[utoipa::path(
     put,
-    path = "/vertiports/{id}",
+    path = "/assets/vertiports/{id}",
     tag = "svc-assets",
     request_body=Vertiport,
     responses(
@@ -701,7 +701,7 @@ pub async fn update_vertiport(
 /// Update/modify a [`Vertipad`] in the database.
 #[utoipa::path(
     put,
-    path = "/vertipads/{id}",
+    path = "/assets/vertipads/{id}",
     tag = "svc-assets",
     request_body=Vertipad,
     responses(
@@ -793,7 +793,7 @@ pub async fn update_asset_group(
 /// Remove a [`Aircraft`] from the database.
 #[utoipa::path(
     delete,
-    path = "/aircraft/{id}",
+    path = "/assets/aircraft/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Aircraft removed from database"),
@@ -838,7 +838,7 @@ pub async fn remove_aircraft(
 /// Remove a [`Vertipad`] from the database.
 #[utoipa::path(
     delete,
-    path = "/vertipads/{id}",
+    path = "/assets/vertipads/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Vertipad removed from database"),
@@ -883,7 +883,7 @@ pub async fn remove_vertipad(
 /// Remove a [`Vertiport`] from the database.
 #[utoipa::path(
     delete,
-    path = "/vertiports/{id}",
+    path = "/assets/vertiports/{id}",
     tag = "svc-assets",
     responses(
         (status = 200, description = "Vertiport removed from database"),

--- a/server/src/rest_api.rs
+++ b/server/src/rest_api.rs
@@ -4,22 +4,25 @@
 pub mod rest_types {
     include!("../../openapi/types.rs");
 }
+use std::str::FromStr;
+
+use prost_types::{FieldMask, Timestamp};
 pub use rest_types::*;
 
 use axum::{extract::Path, Extension, Json};
 use chrono::Utc;
 use hyper::StatusCode;
+use svc_storage_client_grpc::{
+    client::Id,
+    vehicle::{Data, UpdateObject},
+    vertipad::{Data as VertipadData, UpdateObject as VertipadUpdateObject},
+    vertiport::{Data as VertiportData, UpdateObject as VertiportUpdateObject},
+};
 use uuid::Uuid;
 
 use crate::{
-    grpc_clients::GrpcClients,
-    req_debug,
-    structs::Aircraft,
-    structs::AssetsInfo,
-    structs::Vertipad,
-    structs::Vertiport,
-    structs::{AssetGroup, Basics},
-    structs::{Operator, OrderedFloat64},
+    grpc_clients::GrpcClients, req_debug, req_error, structs::Aircraft, structs::AssetGroup,
+    structs::Operator, structs::Vertipad, structs::Vertiport,
 };
 
 //===========================================================
@@ -51,7 +54,7 @@ fn is_uuid(s: &str) -> bool {
     )
 )]
 pub async fn get_operator(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(operator_id): Path<String>,
 ) -> Result<Json<Operator>, (StatusCode, String)> {
     req_debug!("get_operator({})", operator_id);
@@ -59,7 +62,7 @@ pub async fn get_operator(
         return Err((StatusCode::BAD_REQUEST, "Invalid operator id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // TODO let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_operator) {}", &error_msg);
@@ -89,7 +92,7 @@ pub async fn get_operator(
 )]
 /// Get all assets belonging to an operator.
 pub async fn get_all_assets(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(operator_id): Path<String>,
 ) -> Result<Json<Vec<Uuid>>, (StatusCode, String)> {
     req_debug!("get_all_assets({})", operator_id);
@@ -97,13 +100,37 @@ pub async fn get_all_assets(
         return Err((StatusCode::BAD_REQUEST, "Invalid operator id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
+    // let vertiport_client_option = grpc_clients.storage_vertiport.get_client().await;
+    // let vertipad_client_option = grpc_clients.storage_vertipad.get_client().await;
+    // if vertiport_client_option.is_none() || vertipad_client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_all_assets) {}", &error_msg);
     //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
     // }
-    // let mut client = client_option.unwrap();
+
+    // let request = tonic::Request::new(SearchFilter {
+    //     search_field: "".to_string(),
+    //     search_value: "".to_string(),
+    //     page_number: 1,
+    //     results_per_page: 50,
+    // });
+
+    // let mut vertiport_client = vertiport_client_option.unwrap();
+    // let mut vertipad_client = vertipad_client_option.unwrap();
+    // let mut result = Vec::new();
+    // // Get Vertiports
+    // let vertiports = vertiport_client
+    //     .get_all_with_filter(request)
+    //     .await
+    //     .map_err(|e| {
+    //         req_error!("(get_all_assets) Error getting vertiports: {}", e);
+    //         (
+    //             StatusCode::SERVICE_UNAVAILABLE,
+    //             "Error getting vertiports".to_string(),
+    //         )
+    //     })?
+    //     .into_inner()
+    //     .vertiports;
     //TODO
     Ok(Json(vec![]))
 }
@@ -128,7 +155,7 @@ pub async fn get_all_assets(
     )
 )]
 pub async fn get_all_grouped_assets(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(operator_id): Path<String>,
 ) -> Result<Json<Vec<Uuid>>, (StatusCode, String)> {
     req_debug!("get_all_grouped_assets({})", operator_id);
@@ -136,7 +163,7 @@ pub async fn get_all_grouped_assets(
         return Err((StatusCode::BAD_REQUEST, "Invalid operator id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_all_grouped_assets) {}", &error_msg);
@@ -163,7 +190,7 @@ pub async fn get_all_grouped_assets(
     )
 )]
 pub async fn get_all_grouped_assets_delegated_to(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(operator_id): Path<String>,
 ) -> Result<Json<Vec<Uuid>>, (StatusCode, String)> {
     req_debug!("get_all_grouped_assets_delegated_to({})", operator_id);
@@ -171,7 +198,7 @@ pub async fn get_all_grouped_assets_delegated_to(
         return Err((StatusCode::BAD_REQUEST, "Invalid operator id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_all_grouped_assets_delegated_to) {}", &error_msg);
@@ -198,7 +225,7 @@ pub async fn get_all_grouped_assets_delegated_to(
     )
 )]
 pub async fn get_all_grouped_assets_delegated_from(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(operator_id): Path<String>,
 ) -> Result<Json<Vec<Uuid>>, (StatusCode, String)> {
     req_debug!("get_all_grouped_assets_delegated_from({})", operator_id);
@@ -206,7 +233,7 @@ pub async fn get_all_grouped_assets_delegated_from(
         return Err((StatusCode::BAD_REQUEST, "Invalid operator id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_all_grouped_assets_delegated_from) {}", &error_msg);
@@ -246,16 +273,40 @@ pub async fn get_aircraft_by_id(
     }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_aircraft_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vehicle.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_aircraft_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(Json(Aircraft::random()))
+    match client
+        .get_by_id(tonic::Request::new(Id {
+            id: aircraft_id.clone(),
+        }))
+        .await
+    {
+        Ok(response) => {
+            let vehicle = response.into_inner();
+            let aircraft = Aircraft::from(vehicle);
+            if aircraft.is_err() {
+                let error_msg = format!(
+                    "Error converting storage vehicle to aircraft: {}",
+                    aircraft.err().unwrap()
+                );
+                req_error!("(get_aircraft_by_id) {}", &error_msg);
+                return Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg));
+            }
+
+            Ok(Json(aircraft.unwrap()))
+        }
+        Err(e) => {
+            let error_msg = format!("Error getting aircraft from storage: {}", e);
+            req_error!("(get_aircraft_by_id) {}", &error_msg);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg))
+        }
+    }
 }
 
 /// Get an [`Vertipad`] by its id.
@@ -283,16 +334,40 @@ pub async fn get_vertipad_by_id(
     }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_vertipad_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertipad.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_vertipad_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(Json(Vertipad::random()))
+    match client
+        .get_by_id(tonic::Request::new(Id {
+            id: vertipad_id.clone(),
+        }))
+        .await
+    {
+        Ok(response) => {
+            let vertipad = response.into_inner();
+            let vertipad = Vertipad::from(vertipad);
+            if vertipad.is_err() {
+                let error_msg = format!(
+                    "Error converting storage vertipad to vertipad: {}",
+                    vertipad.err().unwrap()
+                );
+                req_error!("(get_vertipad_by_id) {}", &error_msg);
+                return Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg));
+            }
+
+            Ok(Json(vertipad.unwrap()))
+        }
+        Err(e) => {
+            let error_msg = format!("Error getting vertipad from storage: {}", e);
+            req_error!("(get_vertipad_by_id) {}", &error_msg);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg))
+        }
+    }
 }
 
 /// Get an [`Vertiport`] by its id.
@@ -319,15 +394,40 @@ pub async fn get_vertiport_by_id(
         return Err((StatusCode::BAD_REQUEST, "Invalid vertiport id".to_string()));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_vertiport_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
-    //TODO
-    Ok(Json(Vertiport::random()))
+    let client_option = grpc_clients.storage_vertiport.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_vertiport_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
+
+    match client
+        .get_by_id(tonic::Request::new(Id {
+            id: vertiport_id.clone(),
+        }))
+        .await
+    {
+        Ok(response) => {
+            let vertiport = response.into_inner();
+            let vertiport = Vertiport::from(vertiport);
+            if vertiport.is_err() {
+                let error_msg = format!(
+                    "Error converting storage vertiport to vertiport: {}",
+                    vertiport.err().unwrap()
+                );
+                req_error!("(get_vertiport_by_id) {}", &error_msg);
+                return Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg));
+            }
+
+            Ok(Json(vertiport.unwrap()))
+        }
+        Err(e) => {
+            let error_msg = format!("Error getting vertiport from storage: {}", e);
+            req_error!("(get_vertiport_by_id) {}", &error_msg);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg))
+        }
+    }
 }
 
 /// Get an [`AssetGroup`] by its id.
@@ -346,7 +446,7 @@ pub async fn get_vertiport_by_id(
     )
 )]
 pub async fn get_asset_group_by_id(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(asset_group_id): Path<String>,
 ) -> Result<Json<AssetGroup>, (StatusCode, String)> {
     req_debug!("get_asset_group_by_id({})", asset_group_id);
@@ -357,7 +457,7 @@ pub async fn get_asset_group_by_id(
         ));
     }
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_asset_group_by_id) {}", &error_msg);
@@ -391,47 +491,53 @@ pub async fn register_aircraft(
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("register_aircraft()");
 
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
-
-    let _aircraft = Aircraft {
-        basics: Basics {
-            id: Uuid::new_v4().to_string(),
-            name: payload.name,
-            group_id: payload.group_id,
-            owner: payload.owner,
-            whitelist: payload.whitelist,
-            created_at: Utc::now(),
-            updated_at: None,
-            status: payload.status,
-        },
-        model: payload.model,
-        manufacturer: payload.manufacturer,
-        serial_number: payload.serial_number,
-        registration_number: payload.registration_number,
-        description: payload.description,
-        max_payload_kg: OrderedFloat64::from(payload.max_payload_kg),
-        max_range_km: OrderedFloat64::from(payload.max_range_km),
-    };
-
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vehicle.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_aircraft.id().unwrap().to_string())
+    match client
+        .insert(tonic::Request::new(Data {
+            last_vertiport_id: None,
+            vehicle_model_id: Uuid::new_v4().to_string(),
+            serial_number: payload.serial_number,
+            registration_number: payload.registration_number,
+            description: payload.description,
+            asset_group_id: None,
+            schedule: None,
+            last_maintenance: if let Some(last_maintenance) = payload.last_maintenance {
+                let last_maintenance_timezone = Timestamp::from_str(&last_maintenance);
+                Some(last_maintenance_timezone.unwrap())
+            } else {
+                None
+            },
+            next_maintenance: if let Some(next_maintenance) = payload.next_maintenance {
+                let next_maintenance_timezone = Timestamp::from_str(&next_maintenance);
+                Some(next_maintenance_timezone.unwrap())
+            } else {
+                None
+            },
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vehicle Insert={:?}", res);
+            let vehicle_obj = res.into_inner().object;
+            if let Some(vehicle_obj) = vehicle_obj {
+                Ok(vehicle_obj.id)
+            } else {
+                Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Could not insert vehicle".to_string(),
+                ))
+            }
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Register an [`Vertiport`] in the database.
@@ -452,42 +558,39 @@ pub async fn register_vertiport(
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("register_vertiport()");
 
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
-
-    let _vertiport = Vertiport {
-        basics: Basics {
-            id: Uuid::new_v4().to_string(),
-            name: payload.name,
-            group_id: payload.group_id,
-            owner: payload.owner,
-            whitelist: payload.whitelist,
-            created_at: Utc::now(),
-            updated_at: None,
-            status: payload.status,
-        },
-        location: payload.location,
-        description: payload.description,
-    };
-
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertiport.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_vertiport.id().unwrap().to_string())
+    match client
+        .insert(tonic::Request::new(VertiportData {
+            name: payload.name.unwrap_or_else(|| "unnamed".to_string()),
+            description: payload.description.unwrap_or_else(|| "N/A".to_string()),
+            latitude: payload.location.latitude.to_f64(),
+            longitude: payload.location.longitude.to_f64(),
+            schedule: None,
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertiport Insert={:?}", res);
+            let vertiport_obj = res.into_inner().object;
+            if let Some(vertiport_obj) = vertiport_obj {
+                Ok(vertiport_obj.id)
+            } else {
+                Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Could not insert vertiport".to_string(),
+                ))
+            }
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Register an [`Vertipad`] in the database.
@@ -510,34 +613,41 @@ pub async fn register_vertipad(
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("register_vertipad()");
 
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
-
-    let _vertipad = Vertipad {
-        id: Uuid::new_v4().to_string(),
-        location: payload.location,
-        status: payload.status,
-        vertiport_id: payload.vertiport_id,
-    };
-
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertipad.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_vertipad.id.to_string())
+    match client
+        .insert(tonic::Request::new(VertipadData {
+            name: payload.name.unwrap_or_else(|| "unnamed".to_string()),
+            vertiport_id: payload.vertiport_id.clone(),
+            latitude: payload.location.latitude.to_f64(),
+            longitude: payload.location.longitude.to_f64(),
+            schedule: None,
+            enabled: payload.enabled,
+            occupied: payload.occupied,
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertipad Insert={:?}", res);
+            let vertipad_obj = res.into_inner().object;
+            if let Some(vertipad_obj) = vertipad_obj {
+                Ok(vertipad_obj.id)
+            } else {
+                Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Could not insert vertipad".to_string(),
+                ))
+            }
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 //-----------------------------------------------------------
@@ -557,7 +667,7 @@ pub async fn register_vertipad(
     )
 )]
 pub async fn register_asset_group(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Json(payload): Json<RegisterAssetGroupPayload>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("register_asset_group()");
@@ -583,7 +693,7 @@ pub async fn register_asset_group(
     };
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_asset_group_by_id) {}", &error_msg);
@@ -592,7 +702,7 @@ pub async fn register_asset_group(
     // let mut client = client_option.unwrap();
 
     //TODO
-    Ok(_asset_group.id.to_string())
+    Ok(_asset_group.id)
 }
 
 //-----------------------------------------------------------
@@ -604,49 +714,105 @@ pub async fn register_asset_group(
 /// This will update the aircraft's information.
 #[utoipa::path(
     put,
-    path = "/assets/aircraft/{id}",
+    path = "/assets/aircraft",
     tag = "svc-assets",
     request_body=Aircraft,
     responses(
         (status = 200, description = "Aircraft updated in database"),
         (status = 422, description = "Request body is invalid format"),
         (status = 503, description = "Could not connect to other microservice dependencies")
-    ),
-    params(
-        ("id" = String, Path, description = "Aircraft id"),
     )
 )]
 pub async fn update_aircraft(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Json(payload): Json<Aircraft>,
-    // TODO: change _id to id
-    Path(_id): Path<String>,
+    Json(payload): Json<UpdateAircraftPayload>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("update_aircraft()");
 
-    // TODO: validate payload - need to check ownerships, existence, etc.
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
-
+    let vehicle_id = payload.id.clone();
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vehicle.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(payload.id().unwrap().to_string())
+    let response = match client
+        .get_by_id(tonic::Request::new(Id {
+            id: vehicle_id.clone(),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vehicle By ID={:?}", res);
+            res
+        }
+        Err(e) => {
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
+        }
+    };
+
+    let vehicle = response.into_inner().data.unwrap();
+
+    match client
+        .update(tonic::Request::new(UpdateObject {
+            id: vehicle_id.clone(),
+            data: Some(Data {
+                last_vertiport_id: payload
+                    .last_vertiport_id
+                    .unwrap_or(vehicle.last_vertiport_id),
+                vehicle_model_id: payload.vehicle_model_id.unwrap_or(vehicle.vehicle_model_id),
+                serial_number: payload.serial_number.unwrap_or(vehicle.serial_number),
+                registration_number: payload
+                    .registration_number
+                    .unwrap_or(vehicle.registration_number),
+                description: payload.description.unwrap_or(vehicle.description),
+                asset_group_id: payload.asset_group_id.unwrap_or(vehicle.asset_group_id),
+                schedule: payload.schedule.unwrap_or(vehicle.schedule),
+                last_maintenance: if let Some(last_maintenance) = payload.last_maintenance {
+                    if let Some(last_maintenance) = last_maintenance {
+                        let time_stamp_result = Timestamp::from_str(&last_maintenance);
+                        if time_stamp_result.is_ok() {
+                            Some(time_stamp_result.unwrap())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    vehicle.last_maintenance
+                },
+
+                next_maintenance: if let Some(next_maintenance) = payload.next_maintenance {
+                    if let Some(next_maintenance) = next_maintenance {
+                        let time_stamp_result = Timestamp::from_str(&next_maintenance);
+                        if time_stamp_result.is_ok() {
+                            Some(time_stamp_result.unwrap())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    vehicle.next_maintenance
+                },
+            }),
+            mask: Some(FieldMask {
+                paths: payload.mask,
+            }),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vehicle Update={:?}", res);
+            Ok(vehicle_id.clone())
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Update/modify a [`Vertiport`] in the database.
@@ -655,93 +821,138 @@ pub async fn update_aircraft(
 /// perform batch add/remove of vertipads.
 #[utoipa::path(
     put,
-    path = "/assets/vertiports/{id}",
+    path = "/assets/vertiports",
     tag = "svc-assets",
     request_body=Vertiport,
     responses(
         (status = 200, description = "Vertiport updated in database"),
         (status = 422, description = "Request body is invalid format"),
         (status = 503, description = "Could not connect to other microservice dependencies")
-    ),
-    params(
-        ("id" = String, Path, description = "Vertiport id"),
     )
 )]
 pub async fn update_vertiport(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Json(payload): Json<Vertiport>,
-    Path(_id): Path<String>,
+    Json(payload): Json<UpdateVertiportPayload>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("update_vertiport()");
-    // TODO: validate payload - need to check ownerships, existence, etc.
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertiport.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(payload.id().unwrap().to_string())
+    let response = match client
+        .get_by_id(tonic::Request::new(Id {
+            id: payload.id.clone(),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertiport By ID={:?}", res);
+            res
+        }
+        Err(e) => {
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
+        }
+    };
+
+    let vertiport = response.into_inner().data.unwrap();
+
+    match client
+        .update(tonic::Request::new(VertiportUpdateObject {
+            id: payload.id.clone(),
+            data: Some(VertiportData {
+                name: payload.name.unwrap_or(vertiport.name),
+                description: payload.description.unwrap_or(vertiport.description),
+                latitude: payload.latitude.unwrap_or(vertiport.latitude),
+                longitude: payload.longitude.unwrap_or(vertiport.longitude),
+                schedule: payload.schedule.unwrap_or(vertiport.schedule),
+            }),
+            mask: Some(FieldMask {
+                paths: payload.mask,
+            }),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertiport Update={:?}", res);
+            Ok(payload.id.clone())
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Update/modify a [`Vertipad`] in the database.
 #[utoipa::path(
     put,
-    path = "/assets/vertipads/{id}",
+    path = "/assets/vertipads",
     tag = "svc-assets",
     request_body=Vertipad,
     responses(
         (status = 200, description = "Vertipad updated in database"),
         (status = 422, description = "Request body is invalid format"),
         (status = 503, description = "Could not connect to other microservice dependencies")
-    ),
-    params(
-        ("id" = String, Path, description = "Vertipad id"),
     )
 )]
 pub async fn update_vertipad(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Json(payload): Json<Vertipad>,
-    Path(_id): Path<String>,
+    Json(payload): Json<UpdateVertipadPayload>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("update_vertipad()");
-    // TODO: validate payload - need to check ownerships, existence, etc.
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
-
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertipad.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(payload.id.to_string())
+    let response = match client
+        .get_by_id(tonic::Request::new(Id {
+            id: payload.id.clone(),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertipad By ID={:?}", res);
+            res
+        }
+        Err(e) => {
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
+        }
+    };
+
+    let vertipad = response.into_inner().data.unwrap();
+
+    match client
+        .update(tonic::Request::new(VertipadUpdateObject {
+            id: payload.id.clone(),
+            data: Some(VertipadData {
+                name: payload.name.unwrap_or(vertipad.name),
+                latitude: payload.latitude.unwrap_or(vertipad.latitude),
+                longitude: payload.longitude.unwrap_or(vertipad.longitude),
+                enabled: payload.enabled.unwrap_or(vertipad.enabled),
+                occupied: payload.occupied.unwrap_or(vertipad.occupied),
+                schedule: payload.schedule.unwrap_or(vertipad.schedule),
+                vertiport_id: payload.vertiport_id.unwrap_or(vertipad.vertiport_id),
+            }),
+            mask: Some(FieldMask {
+                paths: payload.mask,
+            }),
+        }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertipad Update={:?}", res);
+            Ok(payload.id.clone())
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Update/modify an [`AssetGroup`] in the database.
@@ -760,7 +971,7 @@ pub async fn update_vertipad(
     )
 )]
 pub async fn update_asset_group(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Json(payload): Json<AssetGroup>,
     Path(_id): Path<String>,
 ) -> Result<String, (StatusCode, String)> {
@@ -778,7 +989,7 @@ pub async fn update_asset_group(
     // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_asset_group_by_id) {}", &error_msg);
@@ -787,8 +998,12 @@ pub async fn update_asset_group(
     // let mut client = client_option.unwrap();
 
     //TODO
-    Ok(payload.id.to_string())
+    Ok(payload.id)
 }
+
+//-----------------------------------------------------------
+// Asset Deletion
+//-----------------------------------------------------------
 
 /// Remove a [`Aircraft`] from the database.
 #[utoipa::path(
@@ -805,34 +1020,29 @@ pub async fn update_asset_group(
 )]
 pub async fn remove_aircraft(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("remove_aircraft()");
-    // TODO: validate payload - need to check ownerships, existence,
-    // etc.
-    // TODO: also remove from associated asset group
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vehicle.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_id)
+    match client
+        .delete(tonic::Request::new(Id { id: id.clone() }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertipad Delete={:?}", res);
+            Ok(id)
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Remove a [`Vertipad`] from the database.
@@ -850,34 +1060,29 @@ pub async fn remove_aircraft(
 )]
 pub async fn remove_vertipad(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("remove_vertipad()");
-    // TODO: validate payload - need to check ownerships, existence,
-    // etc.
-    // TODO: also remove from associated asset group and vertiport
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertipad.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_id)
+    match client
+        .delete(tonic::Request::new(Id { id: id.clone() }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertipad Delete={:?}", res);
+            Ok(id)
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Remove a [`Vertiport`] from the database.
@@ -895,34 +1100,29 @@ pub async fn remove_vertipad(
 )]
 pub async fn remove_vertiport(
     Extension(mut grpc_clients): Extension<GrpcClients>,
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("remove_vertiport()");
-    // TODO: validate payload - need to check ownerships, existence,
-    // etc.
-    // TODO: also remove from associated asset group
-
-    // validate payload
-    // to check with the database to validate the registration number
-    //
-    // if !payload.is_valid() {
-    //     return Err((
-    // StatusCode::BAD_REQUEST,
-    //         "Invalid payload format".to_string(),
-    //     ));
-    // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
-    // if client_option.is_none() {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     req_error!("(get_asset_group_by_id) {}", &error_msg);
-    //     return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
-    // }
-    // let mut client = client_option.unwrap();
+    let client_option = grpc_clients.storage_vertiport.get_client().await;
+    if client_option.is_none() {
+        let error_msg = "svc-storage unavailable.".to_string();
+        req_error!("(get_asset_group_by_id) {}", &error_msg);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error_msg));
+    }
+    let mut client = client_option.unwrap();
 
-    //TODO
-    Ok(_id)
+    match client
+        .delete(tonic::Request::new(Id { id: id.clone() }))
+        .await
+    {
+        Ok(res) => {
+            println!("RESPONSE Vertiport Delete={:?}", res);
+            Ok(id)
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
 }
 
 /// Remove an [`AssetGroup`] from the database.
@@ -939,7 +1139,7 @@ pub async fn remove_vertiport(
     )
 )]
 pub async fn remove_asset_group(
-    Extension(mut grpc_clients): Extension<GrpcClients>,
+    Extension(mut _grpc_clients): Extension<GrpcClients>,
     Path(_id): Path<String>,
 ) -> Result<String, (StatusCode, String)> {
     req_debug!("remove_asset_group()");
@@ -958,7 +1158,7 @@ pub async fn remove_asset_group(
     // }
 
     // Get Client
-    let _client_option = grpc_clients.storage.get_client().await;
+    // let _client_option = grpc_clients.storage.get_client().await;
     // if client_option.is_none() {
     //     let error_msg = "svc-storage unavailable.".to_string();
     //     req_error!("(get_asset_group_by_id) {}", &error_msg);


### PR DESCRIPTION
## Changes
* Closes #5 
## Notes
* Hardcoded `created_at` and `updated_at` fields as these fields are not available on `svc-storage` at the moment
* Masks are expected to be generated by frontend clients.
 * For `status` field, all assets are set as `Available` as default. This `status` field doesn't have a counterpart on svc-storage as of yet.
 * `group_id` does not exist on storage for vertiports
 * `description` for vertiports are mandatory on storage but optional for local structs in svc-assets
 * Asset groups and delegations are ignored as they are not the focus of R2 