### PR TITLE
fix: added missing /health route

### DIFF
--- a/log4rs.yaml
+++ b/log4rs.yaml
@@ -4,7 +4,7 @@ appenders:
     kind: console
     encoder:
       # https://medium.com/nikmas-group-rust/advanced-logging-in-rust-with-log4rs-2d712bb322de
-      pattern: "{d(%Y-%m-%d %H:%M:%S)} | {({l}):5.5} | {f}:{L} — {m}{n}"
+      pattern: "{d(%Y-%m-%d %H:%M:%S)} | {I} | {h({l}):5.5} | {f}:{L} | {m}{n}"
   grpc_requests:
     kind: rolling_file
     path: "logs/grpc_requests.log"
@@ -33,17 +33,40 @@ appenders:
         base: 1
     encoder:
       kind: json
+  tests:
+    kind: rolling_file
+    path: "logs/tests.log"
+    policy:
+      trigger:
+        kind: size
+        limit: 20mb
+      roller:
+        kind: fixed_window
+        pattern: logs/tests_{}.gz
+        count: 5
+        base: 1
+    encoder:
+      kind: json
 
 root:
-  level: debug
+  level: info
   appenders:
     - stdout
+
 loggers:
   app::grpc:
-    level: debug
+    level: info
     appenders:
       - grpc_requests
   app::rest:
-    level: debug
+    level: info
     appenders:
       - rest_requests
+  test::ut:
+    level: info
+    appenders:
+      - tests
+  test::it:
+    level: info
+    appenders:
+      - tests

--- a/server/src/grpc/client.rs
+++ b/server/src/grpc/client.rs
@@ -48,7 +48,7 @@ mod tests {
         crate::get_log_handle().await;
         ut_info!("(test_grpc_clients_default) Start.");
 
-        let config = crate::config::Config::default();
+        let config = crate::Config::default();
         let clients = GrpcClients::default(config);
 
         let vehicle = &clients.storage.vehicle;

--- a/server/src/rest/api.rs
+++ b/server/src/rest/api.rs
@@ -4,7 +4,6 @@
 pub mod rest_types {
     include!("../../../openapi/types.rs");
 }
-use prost_types::FieldMask;
 use std::str::FromStr;
 
 pub use rest_types::*;

--- a/server/src/rest/server.rs
+++ b/server/src/rest/server.rs
@@ -85,8 +85,7 @@ pub async fn rest_server(
     let grpc_clients = GrpcClients::default(config.clone());
 
     let app = Router::new()
-        // .merge(SwaggerUi::new("/swagger-ui/*tail").url("/api-doc/openapi.json", ApiDoc::openapi()))
-        // GET endpoints
+        .route("/health", routing::get(api::health_check))
         .route("/assets/operators/:id", routing::get(api::get_operator))
         .route("/assets/demo/aircraft", routing::get(api::get_all_aircraft))
         .route(


### PR DESCRIPTION
While comparing some files for the svc-cargo upgrades, I noticed the /health route was missing for this service.
I also fixed some minor things including the addition of the test loggers in the log config file.